### PR TITLE
fix(Node): use a versão 24

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           cache: npm
-          node-version: "lts/*"
+          node-version: 24
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixa a versão Node 24 uma vez que o repositório não possui um arquivo package.json com as definições básicas para um projeto JS.