### PR TITLE
feat: execute o `semantic-release` com `npx`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: semantic-release
+      - run: npx semantic-release@25
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: github-actions[bot]

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ Este projeto está sob a licença **MIT**. Veja o arquivo [LICENSE](LICENSE) par
 [repo]: http://github.com/renebentes/repository
 [issues]: ../../issues
 [pulls]: ../../pulls
-[commits]: https://www.conventionalcommits.org/en/v2.0.0/
+[commits]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/build/bump.php
+++ b/build/bump.php
@@ -50,7 +50,7 @@ $jsonFiles = [
 ];
 
 $readMeFiles = [
-    '/README.md',
+    '/src/joomla/README.md',
 ];
 
 /*
@@ -188,7 +188,7 @@ foreach ($jsonFiles as $jsonFile) {
 foreach ($readMeFiles as $readMeFile) {
     if (file_exists($rootPath . $readMeFile)) {
         $fileContents = file_get_contents($rootPath . $readMeFile);
-        $fileContents = preg_replace('#v[0-9]+\.[0-9]#', 'v' . $version['main'], $fileContents);
+        $fileContents = preg_replace('#Test v[0-9]+\.[0-9]#', 'Test v' . $version['main'], $fileContents);
         file_put_contents($rootPath . $readMeFile, $fileContents);
     }
 }


### PR DESCRIPTION
A configuração anterior levava em consideração que `semantic-release` estava instalado globalmente, com o `npx` isso não é necessário.